### PR TITLE
dirty fix of broken static resources url of undergrad homepage

### DIFF
--- a/undergrad/index.html
+++ b/undergrad/index.html
@@ -15,16 +15,16 @@
 
     <!-- CSS
     ================================================== -->
-    <link rel="stylesheet" href="/css/base.css">
-    <link rel="stylesheet" href="/css/vendor.css">
-    <link rel="stylesheet" href="/css/main.css">
+    <link rel="stylesheet" href="../css/base.css">
+    <link rel="stylesheet" href="../css/vendor.css">
+    <link rel="stylesheet" href="../css/main.css">
 
     <!-- script
     ================================================== -->
-    <script src="js/modernizr.js"></script>
-    <script src="js/pace.min.js"></script>
+    <script src="../js/modernizr.js"></script>
+    <script src="../js/pace.min.js"></script>
 <script type="text/javascript">
-<!--
+//<!--
     function toggle_visibility(id) {
        var e = document.getElementById(id);
        if(e.style.display == 'block')
@@ -256,9 +256,9 @@
 
     <!-- Java Script
     ================================================== -->
-    <script src="js/jquery-3.2.1.min.js"></script>
-    <script src="js/plugins.js"></script>
-    <script src="js/main.js"></script>
+    <script src="../js/jquery-3.2.1.min.js"></script>
+    <script src="../js/plugins.js"></script>
+    <script src="../js/main.js"></script>
 
 </body>
 


### PR DESCRIPTION
Previously the botton that toggles
navigation menu in mobile view
on the page `/undergrad/index.html`
does not work since the link in
`/undergrad/index.html` linking to
jQuery library source
`/js/jquery-3.2.1.min.js`,
`/js/plugins.js` and
`/js/main.js` is broken.

Quick-fixed by modifying
these relative path to
`../js/jquery-3.2.1.min.js`,
`../js/plugins.js` and
`../js/main.js`.

Similar fixes is applied to
other static resources like
css style sheets
to prevent potential breaks
in the future.

This may NOT be a long-lasting fix.

The icon of the site is missing.
Can't help with that.